### PR TITLE
Implement password recovery with token management

### DIFF
--- a/src/main/java/com/bookbrew/authentication/service/controller/AuthController.java
+++ b/src/main/java/com/bookbrew/authentication/service/controller/AuthController.java
@@ -16,6 +16,7 @@ import com.bookbrew.authentication.service.dto.EmailRecoveryRequestDTO;
 import com.bookbrew.authentication.service.dto.ForgotPasswordRequestDTO;
 import com.bookbrew.authentication.service.dto.LoginRequestDTO;
 import com.bookbrew.authentication.service.dto.PasswordChangeRequestDTO;
+import com.bookbrew.authentication.service.dto.ResetPasswordRequestDTO;
 import com.bookbrew.authentication.service.model.User;
 import com.bookbrew.authentication.service.service.AuthService;
 
@@ -43,9 +44,17 @@ public class AuthController {
     }
 
     @PostMapping("/forgot-password")
-    public ResponseEntity<User> forgotPassword(@Valid @RequestBody ForgotPasswordRequestDTO request) {
-        User user = authService.forgotPassword(request);
-        return ResponseEntity.ok(user);
+    public ResponseEntity<Map<String, String>> forgotPassword(@Valid @RequestBody ForgotPasswordRequestDTO request) {
+        String token = authService.forgotPassword(request);
+        Map<String, String> response = new HashMap<>();
+        response.put("token", token);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<Void> resetPassword(@Valid @RequestBody ResetPasswordRequestDTO request) {
+        authService.resetPassword(request);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/recover-email")

--- a/src/main/java/com/bookbrew/authentication/service/dto/ResetPasswordRequestDTO.java
+++ b/src/main/java/com/bookbrew/authentication/service/dto/ResetPasswordRequestDTO.java
@@ -1,0 +1,22 @@
+package com.bookbrew.authentication.service.dto;
+
+public class ResetPasswordRequestDTO {
+    private String token;
+    private String newPassword;
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+}

--- a/src/main/java/com/bookbrew/authentication/service/model/RecoveryToken.java
+++ b/src/main/java/com/bookbrew/authentication/service/model/RecoveryToken.java
@@ -1,0 +1,85 @@
+package com.bookbrew.authentication.service.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "recovery_tokens")
+public class RecoveryToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private boolean used;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(LocalDateTime expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isUsed() {
+        return used;
+    }
+
+    public void setUsed(boolean used) {
+        this.used = used;
+    }
+
+}

--- a/src/main/java/com/bookbrew/authentication/service/repository/RecoveryTokenRepository.java
+++ b/src/main/java/com/bookbrew/authentication/service/repository/RecoveryTokenRepository.java
@@ -1,0 +1,11 @@
+package com.bookbrew.authentication.service.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bookbrew.authentication.service.model.RecoveryToken;
+
+public interface RecoveryTokenRepository extends JpaRepository<RecoveryToken, Long> {
+    Optional<RecoveryToken> findByToken(String token);
+}


### PR DESCRIPTION
# Pull Request Description
This PR introduces functionalities for manage password recovery tokens to facilitate the password reset process. This includes generating tokens, validating their usage, ensuring expiration, and invalidating them after use.

## Changes Implemented:

### New Endpoints:
**POST /reset-password:** Do reset password.

### Update Endpoints:
**POST /forgot-password:** Generate token to reset password.

### Business Rules:
Each token must be unique and associated with a specific user account.
Password recovery tokens must be single-use and invalidated immediately after use.
Tokens must expire 2 hours after generation if unused.